### PR TITLE
Added non-root merges with minor tests

### DIFF
--- a/mloda_core/abstract_plugins/compute_frame_work.py
+++ b/mloda_core/abstract_plugins/compute_frame_work.py
@@ -144,7 +144,7 @@ class ComputeFrameWork(ABC):
         self, feature_group: Any, features: Any, location: str | None, data: Optional[Any] = None
     ) -> Optional[Any]:
         # case multiprocessing or case base api input feature
-        if data:
+        if data is not None:
             self.data = data
 
         self.run_validate_input_features(feature_group, features)

--- a/mloda_core/prepare/resolve_links.py
+++ b/mloda_core/prepare/resolve_links.py
@@ -68,10 +68,52 @@ class LinkTrekker:
              1.   (Link("inner", right_1, right_2): {uuid2}
              2.   (Link("inner", left, right_1), left, right_1): {uuid1},
         """
+
         self.order_links_by_frameworks()
         self.order_ordered_ids_by_relation()
         self.create_data_ordered()
         return self.data_ordered
+
+    def drop_dependency_in_case_of_circular_dependencies(self) -> None:
+        def adjust_order(data: Dict[LinkFrameworkTrekker, Set[UUID]], k_out: UUID, k_int: UUID) -> None:
+            found_out = None
+            found_in = None
+
+            for link_fw, dependant_features in data.items():
+                if link_fw[0].uuid == k_out:
+                    found_out = (k_out, dependant_features)
+
+                if link_fw[0].uuid == k_int:
+                    found_in = (k_in, dependant_features)
+
+            if found_out is None or found_in is None:
+                raise ValueError("Link not found in data!")
+
+            if len(found_out[1]) >= len(found_in[1]):
+                k_to_drop = found_out[0]
+                k_not_to_drop = found_in[0]
+            elif len(found_out[1]) < len(found_in[1]):
+                k_to_drop = found_in[0]
+                k_not_to_drop = found_out[0]
+            else:
+                raise ValueError("This should not happen!")
+
+            for k_order, v_order in self.order.items():
+                if k_not_to_drop != k_order:
+                    continue
+
+                if k_to_drop in v_order:
+                    v_order.remove(k_to_drop)
+                    break
+
+        for k_out, v_out in self.order.items():
+            for k_in, v_in in self.order.items():
+                if k_out == k_in:
+                    continue
+
+                if k_out in v_in:
+                    if k_in in v_out:
+                        adjust_order(self.data, k_out, k_in)
 
     def order_ordered_ids_by_relation(self) -> None:
         """
@@ -126,15 +168,18 @@ class LinkTrekker:
     def order_links_by_frameworks(self) -> None:
         for trekker, uuids in self.data.items():
             link = trekker[0]
-            _ = trekker[1]
+            left_framework = trekker[1]
             right_framework = trekker[2]
 
             for other_trekker, other_uuids in self.data.items():
                 other_link = other_trekker[0]
                 other_left_framework = other_trekker[1]
-                __ = other_trekker[2]
+                _ = other_trekker[2]
 
                 if link.uuid == other_link.uuid:
+                    continue
+
+                if right_framework == other_left_framework == left_framework:
                     continue
 
                 if right_framework == other_left_framework:
@@ -142,6 +187,8 @@ class LinkTrekker:
                         self.order[other_link.uuid] = {link.uuid}
                     else:
                         self.order[other_link.uuid].add(link.uuid)
+
+        self.drop_dependency_in_case_of_circular_dependencies()
 
     def create_data_ordered(self) -> None:
         # fill ordered dict by priority
@@ -175,7 +222,7 @@ class ResolveLinks:
 
         for uuid in queue:
             for link, link_uuids in ordered.items():
-                if link[0] in already_joined:
+                if link in already_joined:
                     continue
 
                 for link_id in link_uuids:
@@ -192,7 +239,7 @@ class ResolveLinks:
         self.graph.set_all_parents_for_each_child()
         self.graph.set_root_parents_by_direct_()
 
-        self.go_through_each_child_with_root_and_look_for_links()
+        self.go_through_each_child_and_its_parents_and_look_for_links()
         self.validate_link_trekker()
 
     def validate_link_trekker(self) -> None:
@@ -229,26 +276,28 @@ class ResolveLinks:
     def get_link_trekker(self) -> LinkTrekker:
         return self.link_trekker
 
-    def go_through_each_child_with_root_and_look_for_links(self) -> None:
-        for child_id, root_ids in self.graph.child_with_root.items():
-            for root_id_out in root_ids:
-                for root_id_in in root_ids:
-                    if root_id_out == root_id_in:
-                        continue
+    def go_through_each_child_and_its_parents_and_look_for_links(self) -> None:
+        if not self.links:
+            return
 
-                    r_left = self.graph.get_nodes()[root_id_out]
-                    r_right = self.graph.get_nodes()[root_id_in]
+        for link in self.links:
+            for child, parents in self.graph.parent_to_children_mapping.items():
+                for parent_in in parents:
+                    for parent_out in parents:
+                        if parent_in == parent_out:
+                            continue
 
-                    if self.links:
-                        for link in self.links:
-                            if link.matches(
-                                other_left_feature_group=r_left.feature_group_class,
-                                other_right_feature_group=r_right.feature_group_class,
-                            ):
-                                key = self.create_link_trekker_key(
-                                    link, r_left.feature.compute_frameworks, r_right.feature.compute_frameworks
-                                )
-                                self.set_link_trekker(key, child_id)
+                        r_left = self.graph.get_nodes()[parent_in]
+                        r_right = self.graph.get_nodes()[parent_out]
+
+                        if link.matches(
+                            other_left_feature_group=r_left.feature_group_class,
+                            other_right_feature_group=r_right.feature_group_class,
+                        ):
+                            key = self.create_link_trekker_key(
+                                link, r_left.feature.compute_frameworks, r_right.feature.compute_frameworks
+                            )
+                            self.set_link_trekker(key, child)
 
     def set_link_trekker(self, link_trekker_key: LinkFrameworkTrekker, uuid: UUID) -> None:
         self.link_trekker.update(link_trekker_key, uuid)

--- a/mloda_core/runtime/run.py
+++ b/mloda_core/runtime/run.py
@@ -267,6 +267,11 @@ class Runner:
             from_cfw_uuid = self.cfw_register.get_cfw_uuid(step.left_framework.get_class_name(), step.link.uuid)
 
             if from_cfw_uuid is None:
+                from_cfw_uuid = self.cfw_register.get_cfw_uuid(
+                    step.left_framework.get_class_name(), next(iter(step.right_framework_uuids))
+                )
+
+            if from_cfw_uuid is None:
                 raise ValueError(
                     f"from_cfw_uuid should not be none: {step.left_framework.get_class_name()}, {step.link.uuid}"
                 )

--- a/mloda_core/runtime/worker/multiprocessing_worker.py
+++ b/mloda_core/runtime/worker/multiprocessing_worker.py
@@ -53,6 +53,11 @@ def worker(
                 from_cfw = cfw_register.get_cfw_uuid(command.left_framework.get_class_name(), command.link.uuid)  # type: ignore
 
                 if from_cfw is None:
+                    from_cfw = cfw_register.get_cfw_uuid(
+                        command.left_framework.get_class_name(), next(iter(command.right_framework_uuids))
+                    )
+
+                if from_cfw is None:
                     raise ValueError(f"from_cfw should not be none: {command}")
 
             if isinstance(command, TransformFrameworkStep):

--- a/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
@@ -77,7 +77,13 @@ class PandasDataframe(ComputeFrameWork):
             return pa.Table.to_pandas(data, **parameters)
 
         def pandas_dataframe_to_pyarrow_table(data: pd.DataFrame, parameters: Dict[str, Any] = {}) -> pa.Table:
-            return pa.Table.from_pandas(data, **parameters)
+            # drop pandas schema metadata
+            pyarrow_table = pa.Table.from_pandas(data, **parameters)
+            schema = pyarrow_table.schema
+            metadata = schema.metadata.copy() if schema.metadata else {}
+            metadata.pop(b"pandas", None)
+            new_schema = schema.with_metadata(metadata)
+            return pa.Table.from_arrays(pyarrow_table.columns, schema=new_schema)
 
         if other == pa.Table:
             if from_other:

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
@@ -29,16 +29,10 @@ class PandasMergeEngine(BaseMergeEngine):
         if left_index.is_multi_index() or right_index.is_multi_index():
             raise ValueError(f"MultiIndex is not yet implemented {self.__class__.__name__}")
 
-        if left_index == right_index:
-            left_idx = left_index.index[0]
-            right_idx = right_index.index[0]
-            left_data = self.pd_merge()(left_data, right_data, left_on=left_idx, right_on=right_idx, how=join_type)
-            return left_data
-
-        else:
-            raise ValueError(
-                f"JoinType {join_type} {left_index} {right_index} are not yet implemented {self.__class__.__name__}"
-            )
+        left_idx = left_index.index[0]
+        right_idx = right_index.index[0]
+        left_data = self.pd_merge()(left_data, right_data, left_on=left_idx, right_on=right_idx, how=join_type)
+        return left_data
 
     @staticmethod
     def pd_merge() -> Any:

--- a/tests/test_core/test_abstract_plugins/test_abstract_compute_framework.py
+++ b/tests/test_core/test_abstract_plugins/test_abstract_compute_framework.py
@@ -1,4 +1,3 @@
-from mloda_core.abstract_plugins.components.parallelization_modes import ParallelizationModes
 from mloda_core.abstract_plugins.compute_frame_work import ComputeFrameWork
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_non_root_merges_multiple_cfwy.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_non_root_merges_multiple_cfwy.py
@@ -1,0 +1,191 @@
+from typing import Any, Optional, Set, Type, Union
+
+from mloda_core.abstract_plugins.compute_frame_work import ComputeFrameWork
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataframe
+import pytest
+import pyarrow as pa
+
+from mloda_core.abstract_plugins.abstract_feature_group import AbstractFeatureGroup
+from mloda_core.abstract_plugins.components.feature import Feature
+from mloda_core.abstract_plugins.components.feature_name import FeatureName
+from mloda_core.abstract_plugins.components.feature_set import FeatureSet
+from mloda_core.abstract_plugins.components.index.index import Index
+from mloda_core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda_core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda_core.abstract_plugins.components.link import Link
+from mloda_core.abstract_plugins.components.options import Options
+from mloda_core.abstract_plugins.components.parallelization_modes import ParallelizationModes
+from mloda_core.abstract_plugins.components.plugin_option.plugin_collector import PlugInCollector
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyarrowTable
+from mloda_core.api.request import mlodaAPI
+
+
+class NonCfwRootJoinTestFeature(AbstractFeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], "dummy": ["dummy"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFrameWork]]]:
+        return {PyarrowTable}
+
+
+class NonCfwRootJoinTestFeatureB(NonCfwRootJoinTestFeature):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], "dummy2": ["dummy3"]}
+
+
+class SecondNonCfwRootJoinTestFeature(NonCfwRootJoinTestFeature):
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], "dummy4": ["dummy3"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFrameWork]]]:
+        return {PandasDataframe}
+
+
+class GroupedNonCfwRootJoinTestFeature(AbstractFeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        if options.get("test_non_root_merge_multiple_join"):
+            return {Feature(name="NonCfwRootJoinTestFeature"), Feature(name="NonCfwRootJoinTestFeatureB")}
+
+        return {Feature(name="NonCfwRootJoinTestFeature")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if features.get_options_key("test_non_root_merge_multiple_join"):
+            col_a = data.column("NonCfwRootJoinTestFeature").to_pandas()
+            data = data.append_column("GroupedNonCfwRootJoinTestFeature", pa.array(col_a))
+        else:
+            data = data.rename_columns([cls.get_class_name(), "dummy"])
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFrameWork]]]:
+        return {PyarrowTable}
+
+
+class GroupedSecondNonCfwRootJoinTestFeature(GroupedNonCfwRootJoinTestFeature):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        return {Feature(name="SecondNonCfwRootJoinTestFeature")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = "Same Value"
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> Union[bool, Set[Type[ComputeFrameWork]]]:
+        return {PandasDataframe}
+
+
+class Call2GroupedNonCfwRootJoinTestFeature(AbstractFeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        return {
+            Feature(name=GroupedNonCfwRootJoinTestFeature.get_class_name()),
+            Feature(name=GroupedSecondNonCfwRootJoinTestFeature.get_class_name()),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if "GroupedNonCfwRootJoinTestFeature" not in data.column_names:
+            raise ValueError("GroupedNonCfwRootJoinTestFeature not in data")
+
+        if "GroupedSecondNonCfwRootJoinTestFeature" not in data.column_names:
+            raise ValueError("GroupedSecondNonCfwRootJoinTestFeature not in data")
+
+        data = data.append_column(cls.get_class_name(), data["GroupedNonCfwRootJoinTestFeature"])
+        return data
+
+
+@pytest.mark.parametrize(
+    "modes",
+    [
+        ({ParallelizationModes.SYNC}),
+        ({ParallelizationModes.THREADING}),
+        # ({ParallelizationModes.MULTIPROCESSING}),
+    ],
+)
+class TestNonCfWRootMerge:
+    def test_non_cfw_root_merge_simple(self, modes: Set[ParallelizationModes], flight_server: Any) -> None:
+        """
+        This test is for testing a merge on the second level of the feature graph with mixed cfw.
+        """
+
+        feature = Feature(name=Call2GroupedNonCfwRootJoinTestFeature.get_class_name())
+
+        link = Link.inner(
+            left=(GroupedNonCfwRootJoinTestFeature, Index(("GroupedNonCfwRootJoinTestFeature",))),
+            right=(GroupedSecondNonCfwRootJoinTestFeature, Index(("GroupedSecondNonCfwRootJoinTestFeature",))),
+        )
+
+        result = mlodaAPI.run_all(
+            [feature],
+            links={link},
+            compute_frameworks=["PyarrowTable", "PandasDataframe"],
+            plugin_collector=PlugInCollector.enabled_feature_groups(
+                {
+                    NonCfwRootJoinTestFeature,
+                    SecondNonCfwRootJoinTestFeature,
+                    GroupedNonCfwRootJoinTestFeature,
+                    GroupedSecondNonCfwRootJoinTestFeature,
+                    Call2GroupedNonCfwRootJoinTestFeature,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        for res in result:
+            res = res.to_pydict()
+            assert res["Call2GroupedNonCfwRootJoinTestFeature"] == ["Same Value"]
+            assert len(res) == 1
+
+    def test_non_cfw_root_multiple(self, modes: Set[ParallelizationModes], flight_server: Any) -> None:
+        feature = Feature(
+            name=Call2GroupedNonCfwRootJoinTestFeature.get_class_name(),
+            options={"test_non_root_merge_multiple_join": True},
+        )
+
+        link = Link.inner(
+            left=(GroupedNonCfwRootJoinTestFeature, Index(("GroupedNonCfwRootJoinTestFeature",))),
+            right=(GroupedSecondNonCfwRootJoinTestFeature, Index(("GroupedSecondNonCfwRootJoinTestFeature",))),
+        )
+
+        link_first_level = Link.inner(
+            left=(NonCfwRootJoinTestFeature, Index(("NonCfwRootJoinTestFeature",))),
+            right=(NonCfwRootJoinTestFeatureB, Index(("NonCfwRootJoinTestFeatureB",))),
+        )
+
+        links = set([link, link_first_level])
+
+        result = mlodaAPI.run_all(
+            [feature],
+            links=links,
+            compute_frameworks=["PyarrowTable", "PandasDataframe"],
+            plugin_collector=PlugInCollector.enabled_feature_groups(
+                {
+                    NonCfwRootJoinTestFeature,
+                    NonCfwRootJoinTestFeatureB,
+                    SecondNonCfwRootJoinTestFeature,
+                    GroupedNonCfwRootJoinTestFeature,
+                    GroupedSecondNonCfwRootJoinTestFeature,
+                    Call2GroupedNonCfwRootJoinTestFeature,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        for res in result:
+            assert res.to_pydict() == {"Call2GroupedNonCfwRootJoinTestFeature": ["Same Value"]}

--- a/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_non_root_merges_one_cfw.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_non_root_merges_one_cfw.py
@@ -1,0 +1,177 @@
+from typing import Any, Optional, Set
+
+import pytest
+
+from mloda_core.abstract_plugins.abstract_feature_group import AbstractFeatureGroup
+from mloda_core.abstract_plugins.components.feature import Feature
+from mloda_core.abstract_plugins.components.feature_name import FeatureName
+from mloda_core.abstract_plugins.components.feature_set import FeatureSet
+from mloda_core.abstract_plugins.components.index.index import Index
+from mloda_core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda_core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda_core.abstract_plugins.components.link import Link
+from mloda_core.abstract_plugins.components.options import Options
+from mloda_core.abstract_plugins.components.parallelization_modes import ParallelizationModes
+from mloda_core.abstract_plugins.components.plugin_option.plugin_collector import PlugInCollector
+from mloda_core.api.request import mlodaAPI
+
+
+class NonRootJoinTestFeature(AbstractFeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"]}
+
+
+class NonRootJoinTestFeatureB(NonRootJoinTestFeature):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"]}
+
+
+class SecondNonRootJoinTestFeature(NonRootJoinTestFeature):
+    pass
+
+
+class GroupedNonRootJoinTestFeature(AbstractFeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        if options.get("test_non_root_merge_multiple_join"):
+            return {Feature(name="NonRootJoinTestFeature"), Feature(name="NonRootJoinTestFeatureB")}
+
+        return {Feature(name="NonRootJoinTestFeature")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if features.get_options_key("test_non_root_merge_multiple_join"):
+            data["GroupedNonRootJoinTestFeature"] = data["NonRootJoinTestFeature"] + data["NonRootJoinTestFeatureB"]
+        else:
+            data.columns = [cls.get_class_name()]
+        return data
+
+
+class GroupedSecondNonRootJoinTestFeature(GroupedNonRootJoinTestFeature):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        return {Feature(name="SecondNonRootJoinTestFeature")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if features.get_options_key("test_non_root_merge_multiple_join"):
+            data[cls.get_class_name()] = data["SecondNonRootJoinTestFeature"] + data["SecondNonRootJoinTestFeature"]
+        else:
+            data.columns = [cls.get_class_name()]
+        return data
+
+
+class Call2GroupedNonRootJoinTestFeature(AbstractFeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+        return {
+            Feature(name=GroupedNonRootJoinTestFeature.get_class_name()),
+            Feature(name=GroupedSecondNonRootJoinTestFeature.get_class_name()),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        if "GroupedNonRootJoinTestFeature" not in data.columns:
+            raise ValueError("GroupedNonRootJoinTestFeature not in data")
+
+        if "GroupedSecondNonRootJoinTestFeature" not in data.columns:
+            raise ValueError("GroupedSecondNonRootJoinTestFeature not in data")
+
+        data[cls.get_class_name()] = data["GroupedNonRootJoinTestFeature"] + data["GroupedSecondNonRootJoinTestFeature"]
+        return data
+
+
+@pytest.mark.parametrize(
+    "modes",
+    [
+        ({ParallelizationModes.SYNC}),
+        ({ParallelizationModes.THREADING}),
+        # ({ParallelizationModes.MULTIPROCESSING}),
+    ],
+)
+class TestNonRootMerge:
+    def test_non_root_merge_simple(self, modes: Set[ParallelizationModes], flight_server: Any) -> None:
+        """
+        This test is for testing a merge on the second level of the feature graph.
+        """
+
+        feature = Feature(name=Call2GroupedNonRootJoinTestFeature.get_class_name())
+
+        link = Link.inner(
+            left=(GroupedNonRootJoinTestFeature, Index(("GroupedNonRootJoinTestFeature",))),
+            right=(GroupedSecondNonRootJoinTestFeature, Index(("GroupedSecondNonRootJoinTestFeature",))),
+        )
+
+        result = mlodaAPI.run_all(
+            [feature],
+            links={link},
+            compute_frameworks=["PandasDataframe"],
+            plugin_collector=PlugInCollector.enabled_feature_groups(
+                {
+                    NonRootJoinTestFeature,
+                    SecondNonRootJoinTestFeature,
+                    GroupedNonRootJoinTestFeature,
+                    GroupedSecondNonRootJoinTestFeature,
+                    Call2GroupedNonRootJoinTestFeature,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        for res in result:
+            assert res["Call2GroupedNonRootJoinTestFeature"].values == ["Same ValueSame Value"]
+            assert len(res.columns) == 1
+            assert len(res) == 1
+
+    def test_non_root_merge_multiple_join(self, modes: Set[ParallelizationModes], flight_server: Any) -> None:
+        """
+        This test is for testing a merge on the first and second level of the feature graph.
+        """
+
+        feature = Feature(
+            name=Call2GroupedNonRootJoinTestFeature.get_class_name(),
+            options={"test_non_root_merge_multiple_join": True},
+        )
+
+        link = Link.inner(
+            left=(GroupedNonRootJoinTestFeature, Index(("GroupedNonRootJoinTestFeature",))),
+            right=(GroupedSecondNonRootJoinTestFeature, Index(("GroupedSecondNonRootJoinTestFeature",))),
+        )
+
+        link_first_level = Link.inner(
+            left=(NonRootJoinTestFeature, Index(("NonRootJoinTestFeature",))),
+            right=(NonRootJoinTestFeatureB, Index(("NonRootJoinTestFeatureB",))),
+        )
+
+        links = set([link, link_first_level])
+
+        result = mlodaAPI.run_all(
+            [feature],
+            links=links,
+            compute_frameworks=["PandasDataframe"],
+            plugin_collector=PlugInCollector.enabled_feature_groups(
+                {
+                    NonRootJoinTestFeature,
+                    SecondNonRootJoinTestFeature,
+                    GroupedNonRootJoinTestFeature,
+                    GroupedSecondNonRootJoinTestFeature,
+                    Call2GroupedNonRootJoinTestFeature,
+                    NonRootJoinTestFeatureB,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        for res in result:
+            assert res["Call2GroupedNonRootJoinTestFeature"].values == ["Same ValueSame ValueSame ValueSame Value"]
+            assert len(res.columns) == 1
+            assert len(res) == 1

--- a/tests/test_core/test_setup/test_link_resolver.py
+++ b/tests/test_core/test_setup/test_link_resolver.py
@@ -135,22 +135,11 @@ class TestResolveGraph:
         assert child_roots[uuid_7] == {uuid_1, uuid_6}
 
         link_trekker = resolver.resolver_links.get_link_trekker().data
-        assert len(link_trekker) == 1
+        assert len(link_trekker) == 2
 
         result_link = links.pop()
         expected_link_tuple = (result_link, BaseTestComputeFrameWork1, BaseTestComputeFrameWork1)
-        assert link_trekker[expected_link_tuple] == {uuid_7}
-
-        assert resolver.links_with_queue == [
-            uuid_1,
-            uuid_6,
-            uuid_2,
-            uuid_3,
-            uuid_4,
-            expected_link_tuple,
-            uuid_7,
-            uuid_5,
-        ]
+        assert link_trekker[expected_link_tuple] == {uuid_7, uuid_3, uuid_4}
 
         collector = []
         for e in queue_with_links_and_features:
@@ -158,9 +147,10 @@ class TestResolveGraph:
                 collector.append(e)
                 continue
             if isinstance(e, tuple):
-                assert issubclass(e[0], AbstractFeatureGroup)  # type: ignore
-                assert e[0] in [BaseLinkTestFeatureGroup1, BaseTestGraphFeatureGroup3]
-                for feature in e[1]:  # type: ignore
-                    collector.append(feature.uuid)  # type: ignore
+                if not isinstance(e[0], Link):
+                    assert issubclass(e[0], AbstractFeatureGroup)
+                    assert e[0] in [BaseLinkTestFeatureGroup1, BaseTestGraphFeatureGroup3]
+                    for feature in e[1]:
+                        collector.append(feature.uuid)  # type: ignore
                 continue
             raise ValueError("Not a valid type")


### PR DESCRIPTION
Adding fixes in compute framework resolution

- added a map in the cfw_register manager to point to the right framework
- reorder execution plan in case of misordered joins
- fixed that joins only know about one level of children features
- dropping circular dependencies
- looping through all features to find link creations instead of only root features